### PR TITLE
Add power support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
+
 node_js:
   - 12
+  - 14
+
+arch:
+  - amd64
+  - ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.